### PR TITLE
Fixed backup scheduler script

### DIFF
--- a/scripts/schedule_backup.sh
+++ b/scripts/schedule_backup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-task="*/$1 * * * * $PWD/kb.bin_backup.sh"
+task="*/$1 * * * * cd $PWD && ./kb.bin_backup.sh"
 (crontab -l; echo "$task") | crontab -


### PR DESCRIPTION
Backup script will now run in ostis/scripts instead of wherever cron runs it by default